### PR TITLE
add: google index

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -47,6 +47,12 @@ export default async function LocaleLayout({ params, children }: LayoutProps) {
 
   return (
     <html lang={locale} suppressHydrationWarning>
+      <head>
+        <meta
+          name="google-site-verification"
+          content="LgXbQ8fD2jVE3_t2QErjCrFi6SxC8NEYaRC-jGwXLgU"
+        />
+      </head>
       <body
         className={cn(`${plexMono.variable} antialiased`)}
         suppressHydrationWarning


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a static Google Site Verification meta tag in the head of the localized layout, applied before the body content and across all locales.
  * Preserves existing locale routing, notFound handling, and internationalization provider setup.
  * No changes to metadata generation, public APIs, or page behavior.
  * No UI impact for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->